### PR TITLE
test: example of helper file

### DIFF
--- a/R/fire_exp_dir.R
+++ b/R/fire_exp_dir.R
@@ -123,8 +123,8 @@
 #'  each transect starting from the value in meters. The default is
 #'  `c(5000, 5000, 5000)`.
 #' @param interval (Optional) Numeric. The degree interval at which to draw
-#'  the transects for analysis. Can be one of 0.5, 1, 2, 3, 4, 5, 6, 8, or 10.
-#'  The default is `1`.
+#'  the transects for analysis. Can be one of 0.25, 0.5, 1, 2, 3, 4, 5, 6, 8,
+#'  or 10 (factors of 360, ensures even spacing). The default is `1`.
 #' @param thresh_exp (optional) Numeric. The exposure value to use to define
 #'  high exposure as a proportion. Must be between 0-1. The default is `0.6`.
 #' @param thresh_viable (optional) Numeric. The minimum intersection of a
@@ -168,28 +168,28 @@ fire_exp_dir <- function(exposure, value,
                          thresh_viable = 0.8,
                          table = FALSE) {
   stopifnot("`exposure` must be a SpatRaster object"
-            = class(exposure) == "SpatRaster")
-  stopifnot("`exposure` layer must have values between 0-1"
+            = class(exposure) == "SpatRaster",
+            "`exposure` layer must have values between 0-1"
             = (round(terra::minmax(exposure)[1], 0) >= 0
-               && round(terra::minmax(exposure)[2], 0) <= 1))
-  stopifnot("`value` must be a SpatVector object"
-            = class(value) == "SpatVector")
-  stopifnot("`t_lengths` must be a vector of three numeric values"
-            = class(t_lengths) == "numeric" && length(t_lengths) == 3)
-  stopifnot("`interval` must be one of: 0.5, 1, 2, 3, 4, 5, 6, 8, or 10"
-            = interval %in% c(1, 2, 3, 4, 5, 6, 8, 10, 0.5))
-  stopifnot("`thresh_exp` must be a numeric value between 0-1"
-            = thresh_exp >= 0 && thresh_exp <= 1)
-  stopifnot("`thresh_viable` must be a numeric value between 0-1"
+               && round(terra::minmax(exposure)[2], 0) <= 1),
+            "`value` must be a SpatVector object"
+            = class(value) == "SpatVector",
+            "`t_lengths` must be a vector of three numeric values"
+            = class(t_lengths) == "numeric" && length(t_lengths) == 3,
+            "`interval` must be one of: 0.25, 0.5, 1, 2, 3, 4, 5, 6, 8, or 10"
+            = interval %in% c(1, 2, 3, 4, 5, 6, 8, 10, 0.5, 0.25),
+            "`thresh_exp` must be a numeric value between 0-1"
+            = thresh_exp >= 0 && thresh_exp <= 1,
+            "`thresh_viable` must be a numeric value between 0-1"
             = thresh_viable >= 0 && thresh_viable <= 1)
 
   names(exposure) <- "exposure"
   expl <- exposure
 
   stopifnot("`exposure` layer must have a CRS defined"
-            = terra::crs(expl, describe = TRUE)$name != "unknown")
-  stopifnot("`exposure` and `value` must have the same CRS"
-            = terra::crs(expl) == terra::crs(value))
+            = terra::crs(expl) != "",
+            "`exposure` and `value` must have the same CRS"
+            = terra::same.crs(expl, value))
 
 
   if (length(value) > 1) {

--- a/R/fire_exp_dir_map.R
+++ b/R/fire_exp_dir_map.R
@@ -66,10 +66,10 @@ fire_exp_dir_map <- function(transects,
                              labels,
                              title = "Directional Vulnerability") {
   stopifnot("`transects` must be a SpatVector object"
-            = class(transects) == "SpatVector")
-  stopifnot("`zoom_level` must be a number"
-            = class(zoom_level) == "numeric")
-  stopifnot("`title` must be a character string"
+            = class(transects) == "SpatVector",
+            "`zoom_level` must be a number"
+            = class(zoom_level) == "numeric",
+            "`title` must be a character string"
             = class(title) == "character")
 
   if (missing(labels)) {
@@ -128,7 +128,7 @@ fire_exp_dir_map <- function(transects,
     ggplot2::theme_void() +
     ggplot2::labs(
       title = title,
-      subtitle = "Map generated with fireexposuR()",
+      subtitle = "Map generated with {fireexposuR}",
       color = "Transect segment",
       caption = caption
     ) +

--- a/R/fire_exp_dir_multi.R
+++ b/R/fire_exp_dir_multi.R
@@ -62,14 +62,14 @@
 fire_exp_dir_multi <- function(exposure, values, plot = FALSE, full = FALSE,
                                title, ...) {
   stopifnot("`exposure` must be a SpatRaster object"
-            = class(exposure) == "SpatRaster")
-  stopifnot("`exposure` layer must have values between 0-1"
+            = class(exposure) == "SpatRaster",
+            "`exposure` layer must have values between 0-1"
             = (round(terra::minmax(exposure)[1], 0) >= 0
-               && round(terra::minmax(exposure)[2], 0) <= 1))
-  stopifnot("`values` must be a SpatVector object of point or polygon features"
+               && round(terra::minmax(exposure)[2], 0) <= 1),
+            "`values` must be a SpatVector object of point or polygon features"
             = (class(values) == "SpatVector" &&
-                 terra::geomtype(values) %in% c("points", "polygons")))
-  stopifnot("`values` and `exposure` must have the same crs"
+                 terra::geomtype(values) %in% c("points", "polygons")),
+            "`values` and `exposure` must have the same crs"
             = terra::same.crs(values, exposure) == TRUE)
 
   if (missing(title)) {
@@ -133,7 +133,7 @@ fire_exp_dir_multi <- function(exposure, values, plot = FALSE, full = FALSE,
       ggplot2::scale_x_continuous(breaks = c(90, 180, 270, 360),
                                   labels = c("E", "S", "W", "N")) +
       ggplot2::labs(title = title,
-                    subtitle = "Plot generated with fireexposuR()",
+                    subtitle = "Plot generated with {fireexposuR}",
                     y = "Frequency")
     return(plt)
   } else {

--- a/R/fire_exp_dir_plot.R
+++ b/R/fire_exp_dir_plot.R
@@ -58,8 +58,8 @@ fire_exp_dir_plot <- function(transects,
                               labels,
                               title = "Directional Vulnerability") {
   stopifnot("`title` must be a character string"
-            = class(title) == "character")
-  stopifnot("`transects` must be a SpatVector object"
+            = class(title) == "character",
+            "`transects` must be a SpatVector object"
             = class(transects) == "SpatVector")
 
 
@@ -183,6 +183,6 @@ fire_exp_dir_plot <- function(transects,
     ggplot2::scale_x_continuous(breaks = c(90, 180, 270, 360),
                                 labels = c("E", "S", "W", "N")) +
     ggplot2::labs(title = title,
-                  subtitle = "Plot generated with fireexposuR()")
+                  subtitle = "Plot generated with {fireexposuR}")
   return(plt)
 }

--- a/R/fire_exp_extract.R
+++ b/R/fire_exp_extract.R
@@ -63,13 +63,17 @@
 fire_exp_extract <- function(exposure,
                              values) {
   stopifnot("`exposure` must be a SpatRaster object"
-            = class(exposure) == "SpatRaster")
-  stopifnot("`exposure` layer must have values between 0-1"
+            = class(exposure) == "SpatRaster",
+            "`exposure` layer must have values between 0-1"
             = (round(terra::minmax(exposure)[1], 0) >= 0
-               && round(terra::minmax(exposure)[2], 0) <= 1))
-  stopifnot("`values` must be a SpatVector object of point or polygon features"
+               && round(terra::minmax(exposure)[2], 0) <= 1),
+            "`values` must be a SpatVector object of point or polygon features"
             = (class(values) == "SpatVector" &&
-                 terra::geomtype(values) %in% c("points", "polygons")))
+                 terra::geomtype(values) %in% c("points", "polygons")),
+            "`exposure` layer must have a CRS defined"
+            = terra::crs(exposure) != "",
+            "`exposure` and `values` must have the same CRS"
+            = terra::same.crs(exposure, values))
 
   names(exposure) <- "exposure"
   exp <- exposure

--- a/R/fire_exp_extract_vis.R
+++ b/R/fire_exp_extract_vis.R
@@ -80,7 +80,7 @@
 #' aoi <- terra::vect(as.matrix(geom), "polygons", crs = hazard)
 #'
 #' # generate random points within the aoi polygon
-#' points <- terra::spatSample(aoi, 200)
+#' points <- terra::spatSample(aoi, 100)
 #'
 #' # compute exposure
 #' exposure <- fire_exp(hazard)
@@ -103,8 +103,8 @@ fire_exp_extract_vis <- function(values_ext,
   ext <- values_ext
   stopifnot("`values_ext` must be a SpatVector of point or polygon features"
             = (class(ext) == "SpatVector" &&
-                 terra::geomtype(ext) %in% c("points", "polygons")))
-  stopifnot("`values_ext` missing exposure attribute. Use fire_exp_extract()"
+                 terra::geomtype(ext) %in% c("points", "polygons")),
+            "`values_ext` missing exposure attribute. Use fire_exp_extract()"
             = any(terra::names(ext) %in% c("exposure", "mean_exp", "max_exp")))
   if (terra::geomtype(ext) == "polygons") {
     method <- match.arg(method)
@@ -119,7 +119,7 @@ fire_exp_extract_vis <- function(values_ext,
         dplyr::rename(exposure = "max_exp")
     }
   } else {
-    method <- "Point"
+    method <- "NA"
   }
   classify <- match.arg(classify)
 
@@ -138,10 +138,10 @@ fire_exp_extract_vis <- function(values_ext,
 
   # class_breaks checks
   stopifnot("`class_breaks` must be a vector of numbers"
-            = class(class_breaks) == "numeric")
-  stopifnot("`class_breaks` must have 1 as the maximum value"
-            = max(class_breaks) == 1)
-  stopifnot("`class_breaks` must be greater than 0"
+            = class(class_breaks) == "numeric",
+            "`class_breaks` must have 1 as the maximum value"
+            = max(class_breaks) == 1,
+            "`class_breaks` must be greater than 0"
             = class_breaks > 0)
 
   class_labels <- character()
@@ -192,7 +192,7 @@ fire_exp_extract_vis <- function(values_ext,
                      substr(cred, 63, nchar(cred)))
 
     plt <- ggplot2::ggplot() +
-      tidyterra::geom_spatraster_rgb(data = tile, alpha = 0.8) +
+      tidyterra::geom_spatraster_rgb(data = tile, alpha = 0.7) +
       ggspatial::annotation_scale(location = "bl") +
       ggspatial::annotation_north_arrow(
         location = "bl",
@@ -204,7 +204,7 @@ fire_exp_extract_vis <- function(values_ext,
       ggplot2::theme_void() +
       ggplot2::labs(
         title = title,
-        subtitle = "Map generated with fireexposuR()",
+        subtitle = "Map generated with {fireexposuR}",
         caption = caption
       )
 
@@ -235,8 +235,7 @@ fire_exp_extract_vis <- function(values_ext,
       dplyr::count(.data$class_range) %>%
       dplyr::mutate(prop = .data$n / sum(.data$n)) %>%
       dplyr::mutate(method = method) %>%
-      dplyr::mutate(scale = classify) %>%
-      dplyr::select(c("scale", "method", "class_range", "n", "prop"))
+      dplyr::select(c("class_range", "n", "prop", "method"))
     return(df)
   }
 }

--- a/R/fire_exp_map_class.R
+++ b/R/fire_exp_map_class.R
@@ -89,10 +89,12 @@ fire_exp_map_class <- function(exposure, aoi, classify = c("local", "landscape",
                                class_breaks, zoom_level,
                                title = "Classified Exposure") {
   stopifnot("`exposure` must be a SpatRaster object"
-            = class(exposure) == "SpatRaster")
-  stopifnot("`exposure` layer must have values between 0-1"
+            = class(exposure) == "SpatRaster",
+            "`exposure` layer must have values between 0-1"
             = (round(terra::minmax(exposure)[1], 0) >= 0
-               && round(terra::minmax(exposure)[2], 0) <= 1))
+               && round(terra::minmax(exposure)[2], 0) <= 1),
+            "`exposure` layer must have a CRS defined"
+            = terra::crs(exposure) != "")
 
   classify <- match.arg(classify)
 
@@ -101,10 +103,10 @@ fire_exp_map_class <- function(exposure, aoi, classify = c("local", "landscape",
 
   if (!missing(aoi)) {
     stopifnot("`aoi` must be a SpatVector object"
-              = class(aoi) == "SpatVector")
-    stopifnot("`aoi` extent must be within `exposure` extent"
-              = terra::relate(aoi, exposure, "within"))
-    stopifnot("`exposure` and `aoi` must have same CRS"
+              = class(aoi) == "SpatVector",
+              "`aoi` extent must be within `exposure` extent"
+              = terra::relate(aoi, exposure, "within"),
+              "`exposure` and `aoi` must have same CRS"
               = terra::same.crs(exposure, aoi))
 
     exp <- exp %>%
@@ -112,12 +114,12 @@ fire_exp_map_class <- function(exposure, aoi, classify = c("local", "landscape",
       terra::mask(aoi)
     b <- terra::project(aoi, "EPSG:3857")
     # get extent to clip tile
-    e <- terra::rescale(b, 1.3)
+    e <- terra::rescale(b, 1.2)
     expb <- terra::crop(exp, aoi, mask = TRUE) %>%
       terra::project("EPSG:3857")
   } else {
     e <- terra::rescale(terra::as.polygons(terra::ext(exp),
-                                           terra::crs(exp)), 1.3) %>%
+                                           terra::crs(exp)), 1.2) %>%
       terra::project("EPSG:3857")
     expb <- terra::project(exp, "EPSG:3857")
   }

--- a/R/fire_exp_map_cont.R
+++ b/R/fire_exp_map_cont.R
@@ -36,19 +36,21 @@
 #'
 fire_exp_map_cont <- function(exposure, aoi, title = "Wildfire Exposure") {
   stopifnot("`exposure` must be a SpatRaster object"
-            = class(exposure) == "SpatRaster")
-  stopifnot("`exposure` layer must have values between 0-1"
+            = class(exposure) == "SpatRaster",
+            "`exposure` layer must have values between 0-1"
             = (round(terra::minmax(exposure)[1], 0) >= 0
-               && round(terra::minmax(exposure)[2], 0) <= 1))
+               && round(terra::minmax(exposure)[2], 0) <= 1),
+            "`exposure` layer must have a CRS defined"
+            = terra::crs(exposure) != "")
   exp <- exposure
   if (missing(aoi)) {
     r <- exp
   } else {
     stopifnot("`aoi` must be a SpatVector object"
-              = class(aoi) == "SpatVector")
-    stopifnot("`aoi` extent must be within `exposure` extent"
-              = terra::relate(aoi, exposure, "within"))
-    stopifnot("`exposure` and `aoi` must have same CRS"
+              = class(aoi) == "SpatVector",
+              "`aoi` extent must be within `exposure` extent"
+              = terra::relate(aoi, exposure, "within"),
+              "`exposure` and `aoi` must have same CRS"
               = terra::same.crs(exposure, aoi))
     r <- terra::crop(exp, aoi) %>%
       terra::mask(aoi)
@@ -60,7 +62,7 @@ fire_exp_map_cont <- function(exposure, aoi, title = "Wildfire Exposure") {
                                      limits = c(0, 1)) +
     ggplot2::theme_void() +
     ggplot2::labs(title = title,
-                  subtitle = "Map generated with fireexposuR()",
+                  subtitle = "Map generated with {fireexposuR}",
                   fill = "Exposure") +
     ggspatial::annotation_scale(location = "bl") +
     ggspatial::annotation_north_arrow(

--- a/R/fire_exp_validate.R
+++ b/R/fire_exp_validate.R
@@ -87,27 +87,32 @@ fire_exp_validate <- function(burnableexposure, fires, aoi,
   names(burnableexposure) <- "exposure"
   expb <- burnableexposure
   stopifnot("`burnableexposure` must be a SpatRaster object"
-            = class(expb) == "SpatRaster")
-  stopifnot("Linear units of `exposure` layer must be in meters"
-            = terra::linearUnits(expb) == 1)
-  stopifnot("`exposure` layer must have values between 0-1"
-            = (round(terra::minmax(expb)[1], 0) >= 0
-               && round(terra::minmax(expb)[2], 0) <= 1))
-  stopifnot("`fires` must be a SpatVector object"
-            = class(fires) == "SpatVector")
+            = class(expb) == "SpatRaster",
+            "Linear units of `exposure` layer must be in meters"
+            = terra::linearUnits(expb) == 1,
+            "`exposure` layer must have values between 0-1"
+            = (round(terra::minmax(expb)[1], 0)) >= 0
+            && round(terra::minmax(expb)[2], 0) <= 1,
+            "`fires` must be a SpatVector object"
+            = class(fires) == "SpatVector",
+            "`burnableexposure` and `fires` must have same CRS"
+            = terra::same.crs(burnableexposure, fires)
+            )
   if (!missing(aoi)) {
     stopifnot("`aoi` must be a SpatVector object"
-              = class(aoi) == "SpatVector")
+              = class(aoi) == "SpatVector",
+              "`burnableexposure` and `aoi` must have same CRS"
+              = terra::same.crs(burnableexposure, aoi))
   }
 
   class_breaks <- sort(class_breaks)
 
   # class_breaks checks
   stopifnot("`class_breaks` must be a vector of numbers"
-            = class(class_breaks) == "numeric")
-  stopifnot("`class_breaks` must have 1 as the maximum value"
-            = max(class_breaks) == 1)
-  stopifnot("`class_breaks` must be greater than 0"
+            = class(class_breaks) == "numeric",
+            "`class_breaks` must have 1 as the maximum value"
+            = max(class_breaks) == 1,
+            "`class_breaks` must be greater than 0"
             = class_breaks > 0)
 
   class_labels <- character()

--- a/man/fire_exp_dir.Rd
+++ b/man/fire_exp_dir.Rd
@@ -24,8 +24,8 @@ each transect starting from the value in meters. The default is
 \code{c(5000, 5000, 5000)}.}
 
 \item{interval}{(Optional) Numeric. The degree interval at which to draw
-the transects for analysis. Can be one of 0.5, 1, 2, 3, 4, 5, 6, 8, or 10.
-The default is \code{1}.}
+the transects for analysis. Can be one of 0.25, 0.5, 1, 2, 3, 4, 5, 6, 8,
+or 10 (factors of 360, ensures even spacing). The default is \code{1}.}
 
 \item{thresh_exp}{(optional) Numeric. The exposure value to use to define
 high exposure as a proportion. Must be between 0-1. The default is \code{0.6}.}

--- a/man/fire_exp_extract_vis.Rd
+++ b/man/fire_exp_extract_vis.Rd
@@ -105,7 +105,7 @@ geom <- read.csv(system.file(geom_file_path, package = "fireexposuR"))
 aoi <- terra::vect(as.matrix(geom), "polygons", crs = hazard)
 
 # generate random points within the aoi polygon
-points <- terra::spatSample(aoi, 200)
+points <- terra::spatSample(aoi, 100)
 
 # compute exposure
 exposure <- fire_exp(hazard)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,9 @@
+pts <- function(n = 20) {
+  hazard_path <- system.file("extdata", "hazard.tif", package ="fireexposuR")
+  haz <- terra::rast(hazard_path)
+  geo_path <- system.file("extdata", "polygon_geometry.csv", package ="fireexposuR")
+  g <- read.csv(geo_path)
+  v <- terra::vect(as.matrix(g), "polygons", crs = haz)
+  nb <- terra::rasterize(v, haz)
+  terra::spatSample(v, n = 3)
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -5,5 +5,5 @@ pts <- function(n = 20) {
   g <- read.csv(geo_path)
   v <- terra::vect(as.matrix(g), "polygons", crs = haz)
   nb <- terra::rasterize(v, haz)
-  terra::spatSample(v, n = 3)
+  terra::spatSample(v, n = n)
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,9 +1,42 @@
-pts <- function(n = 20) {
+haz <- function() {
   hazard_path <- system.file("extdata", "hazard.tif", package ="fireexposuR")
   haz <- terra::rast(hazard_path)
+}
+
+exposure <- function(nb) {
+  if (missing(nb)) {
+    fire_exp(haz())
+  } else {
+    fire_exp(haz(), no_burn = nb)
+  }
+}
+
+pol <- function() {
+  haz <- haz()
   geo_path <- system.file("extdata", "polygon_geometry.csv", package ="fireexposuR")
-  g <- read.csv(geo_path)
-  v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-  nb <- terra::rasterize(v, haz)
-  terra::spatSample(v, n = n)
+  geo <- read.csv(geo_path)
+  terra::vect(as.matrix(geo), "polygons", crs = haz)
+}
+
+pts <- function(n = 20) {
+  haz <- haz()
+  v <- pol()
+  terra::spatSample(v, n)
+}
+
+nb <- function() {
+  haz <- haz()
+  v <- pol()
+  terra::rasterize(v, haz)
+}
+
+fires <- function(n = 20) {
+  pts <- terra::spatSample(terra::rescale(haz(), 0.8), 20, as.points = TRUE)
+  fires <- terra::buffer(pts, 800)
+}
+
+# landscape scale aoi
+aoi <- function() {
+  e <- c(39, 40, 604, 605) * 10000
+  aoi <- terra::as.polygons(terra::ext(e), crs = haz())
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -32,11 +32,11 @@ nb <- function() {
 
 fires <- function(n = 20) {
   pts <- terra::spatSample(terra::rescale(haz(), 0.8), 20, as.points = TRUE)
-  fires <- terra::buffer(pts, 800)
+  terra::buffer(pts, 800)
 }
 
 # landscape scale aoi
 aoi <- function() {
   e <- c(39, 40, 604, 605) * 10000
-  aoi <- terra::as.polygons(terra::ext(e), crs = haz())
+  terra::as.polygons(terra::ext(e), crs = haz())
 }

--- a/tests/testthat/test-fire_exp_adjust.R
+++ b/tests/testthat/test-fire_exp_adjust.R
@@ -1,16 +1,5 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-
-# tests ========================================================================
-
 test_that("fire_exp_adjust() input checks work", {
+  haz <- haz()
   expect_error(fire_exp_adjust(2),
                "`hazard` must be a SpatRaster object")
   expect_error(fire_exp_adjust(haz),
@@ -26,10 +15,13 @@ test_that("fire_exp_adjust() input checks work", {
 })
 
 test_that("fire_exp_adjust() returns correct object class", {
+  haz <- haz()
   expect_s4_class(fire_exp_adjust(haz, 350), "SpatRaster")
 })
 
 test_that("fire_exp_adjust() runs when input conditions are met", {
+  haz <- haz()
+  nb <- nb()
   expect_no_error(fire_exp_adjust(haz, 350))
   expect_no_error(fire_exp_adjust(haz, 350, nb))
 })

--- a/tests/testthat/test-fire_exp_dir.R
+++ b/tests/testthat/test-fire_exp_dir.R
@@ -1,45 +1,37 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-exp <- fire_exp(haz)
-wkt <- "POINT (400000 6050000)"
-pt <- terra::vect(wkt, crs = haz)
-
-
-# tests ========================================================================
-
 test_that("fire_exp_dir() input checks and function messages work", {
+  pt <- pts(1)
+  pts <- pts(2)
+  exp <- exposure()
   expect_error(fire_exp_dir(2, pt),
                "`exposure` must be a SpatRaster object")
   expect_error(fire_exp_dir(exp, 2),
                "`value` must be a SpatVector object")
   expect_message(fire_exp_dir(exp, pts),
                  "Value object provided has more than one feature")
-  expect_error(fire_exp_dir(exp, pts, t_lengths = c("a", 2, 3)),
+  expect_error(fire_exp_dir(exp, pt, t_lengths = c("a", 2, 3)),
                "`t_lengths` must be a vector of three numeric values")
-  expect_error(fire_exp_dir(exp, pts, t_lengths = c(1, 2)),
+  expect_error(fire_exp_dir(exp, pt, t_lengths = c(1, 2)),
                "`t_lengths` must be a vector of three numeric values")
-  expect_error(fire_exp_dir(exp, pts, interval = "a"),
-               "`interval` must be one of: 0.5, 1, 2, 3, 4, 5, 6, 8, or 10")
-  expect_error(fire_exp_dir(exp, pts, thresh_exp = "a"),
+  expect_error(fire_exp_dir(exp, pt, interval = "a"),
+               "`interval` must be one of: ")
+  expect_error(fire_exp_dir(exp, pt, thresh_exp = "a"),
                "`thresh_exp` must be a numeric value between 0-1")
-  expect_error(fire_exp_dir(exp, pts, thresh_viable = 2),
+  expect_error(fire_exp_dir(exp, pt, thresh_viable = 2),
                "`thresh_viable` must be a numeric value between 0-1")
 })
 
 
 test_that("fire_exp_dir() returns object with correct class", {
+  pt <- pts(1)
+  exp <- exposure()
   expect_s4_class(fire_exp_dir(exp, pt), "SpatVector")
   expect_s3_class(fire_exp_dir(exp, pt, table = TRUE), "data.frame")
 })
 
 test_that("fire_exp_dir() runs when input conditions are met", {
+  pt <- pts(1)
+  v <- pol()
+  exp <- exposure()
   expect_no_error(fire_exp_dir(exp, pt))
   expect_no_error(fire_exp_dir(exp, v))
   expect_no_error(fire_exp_dir(exp, pt, table = TRUE))

--- a/tests/testthat/test-fire_exp_dir_map.R
+++ b/tests/testthat/test-fire_exp_dir_map.R
@@ -1,25 +1,10 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-pt_wkt <- "POINT (400000 6050000)"
-pt <- terra::vect(pt_wkt, crs = haz)
-
-
-
-exp <- fire_exp(haz)
-
-t_pt <- fire_exp_dir(exp, pt)
-t_pol <- fire_exp_dir(exp, v)
-
-
-# tests ========================================================================
-
 test_that("fire_exp_dir_map() input checks work", {
+  exp <- exposure()
+  v <- pol()
+  pt <- pts(1)
+
+  t_pt <- fire_exp_dir(exp, pt)
+  t_pol <- fire_exp_dir(exp, v)
   expect_error(fire_exp_dir_map(2),
                "`transects` must be a SpatVector object")
   expect_error(fire_exp_dir_map(t_pt, title = 2),
@@ -33,10 +18,22 @@ test_that("fire_exp_dir_map() input checks work", {
 })
 
 test_that("fire_exp_dir_map() returns objects with correct class", {
+  exp <- exposure()
+  v <- pol()
+  pt <- pts(1)
+
+  t_pt <- fire_exp_dir(exp, pt)
+  t_pol <- fire_exp_dir(exp, v)
   expect_s3_class(suppressMessages(fire_exp_dir_map(t_pt)), "ggplot")
 })
 
 test_that("fire_exp_dir_map() runs when input conditions are met", {
+  exp <- exposure()
+  v <- pol()
+  pt <- pts(1)
+
+  t_pt <- fire_exp_dir(exp, pt)
+  t_pol <- fire_exp_dir(exp, v)
   expect_no_error(suppressMessages(fire_exp_dir_map(t_pt)))
   expect_no_error(suppressMessages(fire_exp_dir_map(t_pol)))
   expect_no_error(suppressMessages(fire_exp_dir_map(t_pol, value = v)))

--- a/tests/testthat/test-fire_exp_dir_multi.R
+++ b/tests/testthat/test-fire_exp_dir_multi.R
@@ -1,11 +1,4 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 3) # reduced for speed
+
 
 exp <- fire_exp(haz)
 
@@ -18,6 +11,7 @@ ptsout <- terra::spatSample(aoiout, 3)
 # tests ========================================================================
 
 test_that("fire_exp_dir_multi() input checks and function messages work", {
+  pts <- pts(n = 3) # reduced for speed
   expect_error(fire_exp_dir_multi(2, pts),
                "`exposure` must be a SpatRaster object")
   expect_error(fire_exp_dir_multi(exp, 2),
@@ -25,6 +19,7 @@ test_that("fire_exp_dir_multi() input checks and function messages work", {
 })
 
 test_that("fire_exp_dir_multi() runs when input conditions are met", {
+  pts <- pts(n = 3) # reduced for speed
   expect_no_error(fire_exp_dir_multi(exp, pts, plot = TRUE, interval = 10))
   expect_no_error(fire_exp_dir_multi(exp, pts, interval = 10))
 })

--- a/tests/testthat/test-fire_exp_dir_multi.R
+++ b/tests/testthat/test-fire_exp_dir_multi.R
@@ -1,16 +1,5 @@
-
-
-exp <- fire_exp(haz)
-
-
-m <- as.matrix(g)
-m[, "x"] <- m[, "x"] + 50000
-aoiout <- terra::vect(m, "polygons", crs = haz)
-ptsout <- terra::spatSample(aoiout, 3)
-
-# tests ========================================================================
-
 test_that("fire_exp_dir_multi() input checks and function messages work", {
+  exp <- exposure()
   pts <- pts(n = 3) # reduced for speed
   expect_error(fire_exp_dir_multi(2, pts),
                "`exposure` must be a SpatRaster object")
@@ -19,6 +8,7 @@ test_that("fire_exp_dir_multi() input checks and function messages work", {
 })
 
 test_that("fire_exp_dir_multi() runs when input conditions are met", {
+  exp <- exposure()
   pts <- pts(n = 3) # reduced for speed
   expect_no_error(fire_exp_dir_multi(exp, pts, plot = TRUE, interval = 10))
   expect_no_error(fire_exp_dir_multi(exp, pts, interval = 10))

--- a/tests/testthat/test-fire_exp_dir_plot.R
+++ b/tests/testthat/test-fire_exp_dir_plot.R
@@ -1,25 +1,10 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-pt_wkt <- "POINT (400000 6050000)"
-pt <- terra::vect(pt_wkt, crs = haz)
-
-
-
-exp <- fire_exp(haz)
-
-t_pt <- fire_exp_dir(exp, pt)
-t_pol <- fire_exp_dir(exp, v)
-
-
-# tests ========================================================================
-
 test_that("fire_exp_dir_plot() input checks work", {
+  exp <- exposure()
+  v <- pol()
+  pt <- pts(1)
+
+  t_pt <- fire_exp_dir(exp, pt)
+  t_pol <- fire_exp_dir(exp, v)
   expect_error(fire_exp_dir_plot(2),
                "`transects` must be a SpatVector object")
   expect_error(fire_exp_dir_plot(t_pt, title = 2),
@@ -31,10 +16,20 @@ test_that("fire_exp_dir_plot() input checks work", {
 })
 
 test_that("fire_exp_dir_plot() returns objects with correct class", {
+  exp <- exposure()
+  pt <- pts(1)
+
+  t_pt <- fire_exp_dir(exp, pt)
   expect_s3_class(fire_exp_dir_plot(t_pt), "ggplot")
 })
 
 test_that("fire_exp_dir_plot() runs when input conditions are met", {
+  exp <- exposure()
+  v <- pol()
+  pt <- pts(1)
+
+  t_pt <- fire_exp_dir(exp, pt)
+  t_pol <- fire_exp_dir(exp, v)
   expect_no_error(fire_exp_dir_plot(t_pt))
   expect_no_error(fire_exp_dir_plot(t_pol))
   expect_no_error(fire_exp_dir_plot(t_pt, labels = c("blah", "blah", "blah")))

--- a/tests/testthat/test-fire_exp_extract.R
+++ b/tests/testthat/test-fire_exp_extract.R
@@ -1,19 +1,7 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-exp <- fire_exp(haz)
-
-pols <- terra::buffer(pts, 100)
-
-# tests ========================================================================
-
 test_that("fire_exp_extract() input checks work", {
+  exp <- exposure()
+  pts <- pts(20)
+  pols <- terra::buffer(pts, 200)
   expect_error(fire_exp_extract(2),
                "`exposure` must be a SpatRaster object")
   expect_error(fire_exp_extract(exp, 2),
@@ -21,11 +9,17 @@ test_that("fire_exp_extract() input checks work", {
 })
 
 test_that("fire_exp_extract() returns objects with correct class", {
+  exp <- exposure()
+  pts <- pts(20)
+  pols <- terra::buffer(pts, 200)
   expect_s4_class(fire_exp_extract(exp, pts), "SpatVector")
   expect_s4_class(fire_exp_extract(exp, pols), "SpatVector")
 })
 
 test_that("fire_exp_extract() runs when input conditions are met", {
+  exp <- exposure()
+  pts <- pts(20)
+  pols <- terra::buffer(pts, 200)
   expect_no_error(fire_exp_extract(exp, pols))
   expect_no_error(fire_exp_extract(exp, pts))
 })

--- a/tests/testthat/test-fire_exp_extract_vis.R
+++ b/tests/testthat/test-fire_exp_extract_vis.R
@@ -1,22 +1,9 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-exp <- fire_exp(haz)
-
-pols <- terra::buffer(pts, 100)
-
-ext_pts <- fire_exp_extract(exp, pts)
-ext_pols <- fire_exp_extract(exp, pols)
-
-# tests ========================================================================
-
 test_that("fire_exp_extract_vis() input checks work", {
+  exp <- exposure()
+  pts <- pts(20)
+  pols <- terra::buffer(pts, 200)
+  ext_pts <- fire_exp_extract(exp, pts)
+  ext_pols <- fire_exp_extract(exp, pols)
   expect_error(fire_exp_extract_vis(2),
                "`values_ext` must be a SpatVector")
   expect_error(fire_exp_extract_vis(pts),
@@ -30,11 +17,19 @@ test_that("fire_exp_extract_vis() input checks work", {
 })
 
 test_that("fire_exp_extract_vis() returns objects with correct class", {
+  exp <- exposure()
+  pts <- pts(20)
+  ext_pts <- fire_exp_extract(exp, pts)
   expect_s3_class(fire_exp_extract_vis(ext_pts), "data.frame")
   expect_s3_class(fire_exp_extract_vis(ext_pts, map = TRUE), "ggplot")
 })
 
 test_that("fire_exp_extract_vis() runs when input conditions are met", {
+  exp <- exposure()
+  pts <- pts(20)
+  pols <- terra::buffer(pts, 200)
+  ext_pts <- fire_exp_extract(exp, pts)
+  ext_pols <- fire_exp_extract(exp, pols)
   expect_no_error(fire_exp_extract_vis(ext_pts))
   expect_no_error(fire_exp_extract_vis(ext_pts, map = TRUE))
   expect_no_error(fire_exp_extract_vis(ext_pts, classify = "lan"))

--- a/tests/testthat/test-fire_exp_map_class.R
+++ b/tests/testthat/test-fire_exp_map_class.R
@@ -1,22 +1,14 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-exp <- fire_exp(haz)
-
-cropexp <- terra::crop(exp, terra::rescale(v, 0.5))
-
-nocrs <- exp
-terra::crs(nocrs) <- ""
-
-# tests ========================================================================
-
 test_that("fire_exp_map_class() input checks and function messages work", {
+  exp <- exposure()
+  v <- pol()
+
+  cropexp <- terra::crop(exp, terra::rescale(v, 0.5))
+
+  nocrs <- exp
+  terra::crs(nocrs) <- ""
+  v2 <- v
+  terra::crs(v2) <- ""
+
   expect_error(fire_exp_map_class(2, "loc", v),
                "`exposure` must be a SpatRaster object")
   expect_error(fire_exp_map_class(exp * 2, v),
@@ -28,14 +20,20 @@ test_that("fire_exp_map_class() input checks and function messages work", {
   expect_error(fire_exp_map_class(exp, v, "blah"),
                "'arg' should be one of")
   expect_error(fire_exp_map_class(nocrs, v, "lan"),
+               "`exposure` layer must have a CRS defined")
+  expect_error(fire_exp_map_class(exp, v2, "lan"),
                "`exposure` and `aoi` must have same CRS")
 })
 
 test_that("fire_exp_map_class() returns object with correct class", {
+  exp <- exposure()
+  v <- pol()
   expect_s3_class(fire_exp_map_class(exp, aoi = v), "ggplot")
 })
 
 test_that("fire_exp_map_class() runs when input conditions are met", {
+  exp <- exposure()
+  v <- pol()
   expect_no_error(fire_exp_map_class(exp, v, "lan"))
   expect_no_error(fire_exp_map_class(exp, v, "cus", class_breaks = c(0.2, 1)))
 })

--- a/tests/testthat/test-fire_exp_map_cont.R
+++ b/tests/testthat/test-fire_exp_map_cont.R
@@ -1,22 +1,14 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-exp <- fire_exp(haz)
-
-cropexp <- terra::crop(exp, terra::rescale(v, 0.5))
-
-nocrs <- exp
-terra::crs(nocrs) <- ""
-
-# tests ========================================================================
-
 test_that("fire_exp_map_cont() input checks and function messages work", {
+  exp <- exposure()
+  v <- pol()
+
+  cropexp <- terra::crop(exp, terra::rescale(v, 0.5))
+
+  nocrs <- exp
+  terra::crs(nocrs) <- ""
+  v2 <- v
+  terra::crs(v2) <- ""
+
   expect_condition(fire_exp_map_cont(2),
                    "`exposure` must be a SpatRaster object")
   expect_condition(fire_exp_map_cont(exp * 2),
@@ -26,14 +18,20 @@ test_that("fire_exp_map_cont() input checks and function messages work", {
   expect_condition(fire_exp_map_cont(cropexp, v),
                    "`aoi` extent must be within `exposure` extent")
   expect_condition(fire_exp_map_cont(nocrs, v),
+                   "`exposure` layer must have a CRS")
+  expect_condition(fire_exp_map_cont(exp, v2),
                    "`exposure` and `aoi` must have same CRS")
 })
 
 test_that("fire_exp_map_cont() returns object with correct class", {
+  exp <- exposure()
   expect_s3_class(suppressMessages(fire_exp_map_cont(exp)), "ggplot")
 })
 
 test_that("fire_exp_map_cont() runs when input conditions are met", {
+  exp <- exposure()
+  v <- pol()
+  # messages suppressed because terra outputs a message for bigger rasters
   expect_no_error(suppressMessages(fire_exp_map_cont(exp)))
   expect_no_error(suppressMessages(fire_exp_map_cont(exp, v)))
 })

--- a/tests/testthat/test-fire_exp_summary.R
+++ b/tests/testthat/test-fire_exp_summary.R
@@ -1,17 +1,6 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-exp <- fire_exp(haz)
-
-# tests ========================================================================
-
 test_that("fire_exp_summary() input checks work", {
+  exp <- exposure()
+  v <- pol()
   expect_condition(fire_exp_summary(2),
                    "`exposure` must be a SpatRaster object")
   expect_condition(fire_exp_summary(exp, 2),
@@ -21,10 +10,14 @@ test_that("fire_exp_summary() input checks work", {
 })
 
 test_that("fire_exp_summary() returns objects with correct class", {
+  exp <- exposure()
+  v <- pol()
   expect_s3_class(fire_exp_summary(exp, v), "data.frame")
 })
 
 test_that("fire_exp_summary() runs when input conditions are met", {
+  exp <- exposure()
+  v <- pol()
   expect_no_error(fire_exp_summary(exp, v, "loc"))
   expect_no_error(fire_exp_summary(exp, v, "lan"))
   expect_no_error(fire_exp_summary(exp, classify = "lan"))

--- a/tests/testthat/test-fire_exp_validate.R
+++ b/tests/testthat/test-fire_exp_validate.R
@@ -1,32 +1,6 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-expnb <- fire_exp(haz, no_burn = nb)
-
-pts <- terra::spatSample(terra::rescale(haz, 0.8), 30, as.points = TRUE)
-fires <- terra::buffer(pts, 800)
-
-e <- c(39, 40, 604, 605) * 10000
-aoi <- terra::as.polygons(terra::ext(e), crs = haz)
-
-set.seed(0)
-output1 <- fire_exp_validate(expnb, fires)
-
-set.seed(1)
-output2 <- fire_exp_validate(expnb, fires)
-
-set.seed(0)
-output3 <- fire_exp_validate(expnb, fires)
-
-# tests ========================================================================
-
 test_that("fire_exp_validate() input checks and function messages work", {
+  expnb <- exposure(nb())
+  fires <- fires()
   expect_error(fire_exp_validate(2, fires),
                "`burnableexposure` must be a SpatRaster object")
   expect_error(fire_exp_validate(expnb, 2),
@@ -36,15 +10,28 @@ test_that("fire_exp_validate() input checks and function messages work", {
 })
 
 test_that("valdiateexp() returns object with correct class", {
+  expnb <- exposure(nb())
+  fires <- fires()
   expect_s3_class(fire_exp_validate(expnb, fires), "data.frame")
 })
 
 test_that("fire_exp_validate() runs when input conditions are met", {
+  expnb <- exposure(nb())
+  fires <- fires()
+  aoi <- aoi()
   expect_no_error(fire_exp_validate(expnb, fires))
   expect_no_error(fire_exp_validate(expnb, fires, aoi))
 })
 
 test_that("fire_exp_validate() randomly samples", {
+  expnb <- exposure(nb())
+  fires <- fires()
+  set.seed(0)
+  output1 <- fire_exp_validate(expnb, fires)
+  set.seed(1)
+  output2 <- fire_exp_validate(expnb, fires)
+  set.seed(0)
+  output3 <- fire_exp_validate(expnb, fires)
   expect_false(identical(output1, output2))
   expect_true(identical(output1, output3))
 })

--- a/tests/testthat/test-fire_exp_validate_plot.R
+++ b/tests/testthat/test-fire_exp_validate_plot.R
@@ -1,31 +1,7 @@
-# repeat test data
-filepath <- "extdata/hazard.tif"
-haz <- terra::rast(system.file(filepath, package = "fireexposuR"))
-filepath <- "extdata/polygon_geometry.csv"
-g <- read.csv(system.file(filepath, package = "fireexposuR"))
-v <- terra::vect(as.matrix(g), "polygons", crs = haz)
-nb <- terra::rasterize(v, haz)
-pts <- terra::spatSample(v, 20)
-
-expnb <- fire_exp(haz, no_burn = nb)
-
-pts <- terra::spatSample(terra::rescale(haz, 0.8), 30, as.points = TRUE)
-fires <- terra::buffer(pts, 800)
-
-e <- c(39, 40, 604, 605) * 10000
-aoi <- terra::as.polygons(terra::ext(e), crs = haz)
-
-set.seed(0)
-output1 <- fire_exp_validate(expnb, fires)
-
-set.seed(1)
-output2 <- fire_exp_validate(expnb, fires)
-
-set.seed(0)
-output3 <- fire_exp_validate(expnb, fires)
-
-# tests ========================================================================
-
 test_that("fire_exp_valdiate_plot() returns object with correct class", {
+  expnb <- exposure(nb())
+  fires <- fires()
+  set.seed(0)
+  output1 <- fire_exp_validate(expnb, fires)
   expect_s3_class(fire_exp_validate_plot(output1), "ggplot")
 })


### PR DESCRIPTION
:wave: @heyairf just a suggestion! While looking at the macOS failures I noticed many test files have "top-level code". I'd recommend that instead you define functions that create the data in a so-called [helper file](https://r-pkgs.org/testing-design.html#testthat-helper-files), and call these functions from within the tests. The functions could even get longer names (pts is very short).

This way when a test fails, you don't need to scroll up to find where the data was created: the function from the helper file is available with `devtools::load_all()`. See https://r-pkgs.org/testing-design.html#plan-for-test-failure

In `test-fire_exp_validate.R`, two objects called pts are defined, one of them could be removed for clarity.